### PR TITLE
Do not execute Select-String when user profile file is missing

### DIFF
--- a/profile-install.ps1
+++ b/profile-install.ps1
@@ -1,7 +1,10 @@
 if (Invoke-Command -ScriptBlock {
   $command = ". `"${PSScriptRoot}\configure.ps1`""
 
-  $result = Select-String -Pattern $command -Path $profile -SimpleMatch
+  $result = $null
+  if (Test-Path -Path $profile) {
+    $result = Select-String -Pattern $command -Path $profile -SimpleMatch
+  }
 
   if ($result -ne $null) {
     Write-Host 'Skipping installation. The configure.ps1 script is already executed by the user profile file'


### PR DESCRIPTION
# Why

When the `profile-install.ps1` script is executed by a user, whose user profile file does not exist, the script logs the `ItemNotFoundException` exception.

```
PS C:\Users\example\test> .\profile-install.ps1
Select-String : Cannot find path 'C:\Users\example\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1' because it does not exist.
At D:\projects\powershell-session-configurator\profile-install.ps1:4 char:13
+   $result = Select-String -Pattern $command -Path $profile -SimpleMat ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\exampl...ell_profile.ps1:String) [Select-String], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.SelectStringCommand

Installing...
Modyfing the user profile file...
Configuring the current PowerShell session...
Installed sucessfully
C:\Users\example\test>
```

It is caused by executing `Select-String` on a non-existent file.

# What

The `profile-install.ps1` script is updated to omit the search cmdlet execution when the user profile is missing.