### PR TITLE
Add support for kubectx

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The `configure.ps1` script configures predefined tools in the current PowerShell
 - [Tools](#tools)
   - [K3d](#k3d)
   - [Kubectl](#kubectl)
+  - [Kubectx](#kubectx)
 
 ## Usage
 
@@ -36,11 +37,15 @@ to remove it.
 
 ### K3d
 
-When the [`k3d`](https://k3d.io/) tool is available on `$env:PATH` the configurator enables the auto-completion feature.
+When [`k3d`](https://k3d.io/) is available on `$env:PATH`, the configurator enables the auto-completion feature.
 
 ### Kubectl
 
-When the [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) tool is available on `$env:PATH` the configurator:
+When [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) is available on `$env:PATH`, the configurator:
 
 - enables the auto-completion feature
 - adds the `k` alias
+
+### Kubectx
+
+When [`kubectx`](https://github.com/ahmetb/kubectx) is available on `$env:PATH`, the configurator enables the auto-completion feature.

--- a/scripts/builtin-completion.ps1
+++ b/scripts/builtin-completion.ps1
@@ -1,5 +1,5 @@
 Invoke-Command -ScriptBlock {
-  $generatedDir = "${PSScriptRoot}\..\generated"
+  $rootDir = "${PSScriptRoot}\.."
 
   function SetupAll {
     SetupKubectl
@@ -30,7 +30,7 @@ Invoke-Command -ScriptBlock {
       FilePath = $null
     }
 
-    $completionPath = "${generatedDir}\${commandName}.ps1"
+    $completionPath = "${rootDir}\generated\${commandName}.ps1"
     $result.FilePath = $completionPath
 
     $command = Get-Command -Name $commandName -ErrorAction 'SilentlyContinue'

--- a/scripts/static-completion.ps1
+++ b/scripts/static-completion.ps1
@@ -1,0 +1,44 @@
+Invoke-Command -ScriptBlock {
+  $rootDir = "${PSScriptRoot}\.."
+
+  function SetupAll {
+    UpdateCompletionScript -CommandName 'kubectx' > $null
+  }
+
+  function UpdateCompletionScript {
+    param (
+      [string]$CommandName
+    )
+
+    $result = [pscustomobject]@{
+      Exists = $false;
+      Updated = $false;
+      FilePath = $null
+    }
+
+    $destCompletionPath = "${rootDir}\generated\${commandName}.ps1"
+    $result.FilePath = $completionPath
+
+    $command = Get-Command -Name $commandName -ErrorAction 'SilentlyContinue'
+    if ($command -ne $null) {
+      $result.Exists = $true
+      $recreate = $true
+      $destCompletionFile = Get-Item -Path $destCompletionPath -ErrorAction 'SilentlyContinue'
+      $srcCompletionPath = "${rootDir}\static\completion\${commandName}.ps1"
+      if ($destCompletionFile -ne $null) {
+        $sourceCompletionFileTime = Get-ItemProperty -Path $srcCompletionPath -Name 'LastWriteTime'
+        $recreate = $destCompletionFile.LastWriteTime -lt $sourceCompletionFileTime.LastWriteTime
+      }
+      if ($recreate) {
+        Copy-Item -Path $srcCompletionPath -Destination $destCompletionPath
+        $result.Updated = $true
+      }
+    } elseif (Test-Path -Path $destCompletionPath -PathType 'Leaf') {
+      Remove-Item -Path $destCompletionPath
+    }
+
+    return $result
+  }
+
+  SetupAll
+}

--- a/static/completion/kubectx.ps1
+++ b/static/completion/kubectx.ps1
@@ -1,0 +1,112 @@
+
+# Copyright 2023 Adam Gabryś
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script based on the kubectl PowerShell completion
+
+function __kubectx_debug {
+  if ($env:BASH_COMP_DEBUG_FILE) {
+    "${args}" | Out-File -Append -FilePath "${env:BASH_COMP_DEBUG_FILE}"
+  }
+}
+
+filter __kubectx_escapeStringWithSpecialChars {
+  $_ -replace '\s|#|@|\$|;|,|''|\{|\}|\(|\)|"|`|\||<|>|&', '`$&'
+}
+
+Register-ArgumentCompleter -CommandName 'kubectx' -ScriptBlock {
+  param(
+    $WordToComplete,
+    $CommandAst,
+    $CursorPosition
+  )
+
+  # Get the current command line and convert into a string
+  $command = $CommandAst.CommandElements
+  $command = "${command}"
+
+  __kubectx_debug ''
+  __kubectx_debug '========= starting completion logic =========='
+  __kubectx_debug "WordToComplete: ${WordToComplete} Command: ${command} CursorPosition: ${CursorPosition}"
+
+  # The user could have moved the cursor backwards on the command-line
+  # We need to trigger completion from the $CursorPosition location, so we need
+  # to truncate the command-line ($command) up to the $CursorPosition location
+  # Make sure the $command is longer then the $CursorPosition before we truncate
+  # This happens because the $command does not include the last space
+  if ($command.Length -gt $CursorPosition) {
+    $command = $command.Substring(0, $CursorPosition)
+  }
+  __kubectx_debug "Truncated command: ${command}"
+
+  $program, $arguments = $command.Split(' ', 2)
+  if ($arguments -eq $null) {
+    $arguments = @()
+    __kubectx_debug "No arguments"
+  } else {
+    $arguments = $arguments.Split(' ')
+    __kubectx_debug "Arguments: ${arguments}"
+  }
+
+  # When at least one agrument is passed, we should not provide more completions
+  if ($WordToComplete -eq '' -and $arguments.Length -gt 0) {
+    __kubectx_debug "Only one argument is supported. No more completions"
+    return
+  }
+
+  # We cannot use $WordToComplete because it has the wrong values
+  # if the cursor was moved so use the last argument
+  if ($WordToComplete -ne '') {
+    $WordToComplete = $arguments[-1]
+  }
+  __kubectx_debug "New WordToComplete: ${WordToComplete}"
+
+  __kubectx_debug "Calling ${program} to get available contexts"
+  # Call the command store the output in $out and redirect stderr and stdout to null
+  # $values is an array contains each line per element
+  Invoke-Expression -OutVariable values "$program" 2>&1 | Out-Null
+  __kubectx_debug "The completions are: ${values}"
+
+  # Filter the result
+  $values = $values | Where-Object {
+    $_ -like "${WordToComplete}*"
+  }
+
+  # Get the current mode
+  $mode = (Get-PSReadLineKeyHandler | Where-Object {$_.Key -eq 'Tab'}).Function
+  __kubectx_debug "Mode: $mode"
+
+  $values | ForEach-Object {
+    # PowerShell supports three different completion modes
+    # - TabCompleteNext (default windows style - on each key press the next option is displayed)
+    # - Complete (works like bash)
+    # - MenuComplete (works like zsh)
+    # You set the mode with Set-PSReadLineKeyHandler -Key Tab -Function <mode>
+
+    # CompletionResult Arguments:
+    # 1) CompletionText text to be used as the auto completion result
+    # 2) ListItemText   text to be displayed in the suggestion list
+    # 3) ResultType     type of completion result
+    # 4) ToolTip        text for the tooltip with details about the object
+
+    # kubectx supports only one parameter, so we do not need to add additional spaces at the end
+    # The same completion result is returned for all modes
+    [System.Management.Automation.CompletionResult]::new(
+      $($_ | __kubectl_escapeStringWithSpecialChars),
+      $_,
+      'ParameterValue',
+      $_
+    )
+  }
+}


### PR DESCRIPTION
# Why

The `kubectx` tool available on Windows does not provide an interactive mode. It means users have to type a context name instead of choose it from a list.

# What

This commit adds autocompletion script based on the `kubectl` script. The script was simplified a lot, because `kubectx` supports only one parameter - the context name.