### PR TITLE
Add support for kubens

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The `configure.ps1` script configures predefined tools in the current PowerShell
   - [K3d](#k3d)
   - [Kubectl](#kubectl)
   - [Kubectx](#kubectx)
+  - [Kubens](#kubens)
 
 ## Usage
 
@@ -49,3 +50,7 @@ When [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/) is avail
 ### Kubectx
 
 When [`kubectx`](https://github.com/ahmetb/kubectx) is available on `$env:PATH`, the configurator enables the auto-completion feature.
+
+### Kubens
+
+When [`kubens`](https://github.com/ahmetb/kubectx) is available on `$env:PATH`, the configurator enables the auto-completion feature.

--- a/scripts/builtin-completion.ps1
+++ b/scripts/builtin-completion.ps1
@@ -30,10 +30,10 @@ Invoke-Command -ScriptBlock {
       FilePath = $null
     }
 
-    $completionPath = "${rootDir}\generated\${commandName}.ps1"
+    $completionPath = "${rootDir}\generated\${CommandName}.ps1"
     $result.FilePath = $completionPath
 
-    $command = Get-Command -Name $commandName -ErrorAction 'SilentlyContinue'
+    $command = Get-Command -Name $CommandName -ErrorAction 'SilentlyContinue'
     if ($command -ne $null) {
       $result.Exists = $true
       $recreate = $true
@@ -43,7 +43,7 @@ Invoke-Command -ScriptBlock {
         $recreate = $completionFile.LastWriteTime -lt $commandTime.LastWriteTime
       }
       if ($recreate) {
-        Invoke-Expression -Command "${commandName} completion powershell" | Set-Content -Path $completionPath
+        Invoke-Expression -Command "${CommandName} completion powershell" | Set-Content -Path $completionPath
         $result.Updated = $true
       }
     } elseif (Test-Path -Path $completionPath -PathType 'Leaf') {

--- a/scripts/template-completion.ps1
+++ b/scripts/template-completion.ps1
@@ -2,12 +2,14 @@ Invoke-Command -ScriptBlock {
   $rootDir = "${PSScriptRoot}\.."
 
   function SetupAll {
-    UpdateCompletionScript -CommandName 'kubectx' > $null
+    UpdateCompletionScript -CommandName 'kubectx' -TemplateName 'kube-ctx-ns' > $null
+    UpdateCompletionScript -CommandName 'kubens' -TemplateName 'kube-ctx-ns' > $null
   }
 
   function UpdateCompletionScript {
     param (
-      [string]$CommandName
+      [string]$CommandName,
+      [string]$TemplateName
     )
 
     $result = [pscustomobject]@{
@@ -16,22 +18,23 @@ Invoke-Command -ScriptBlock {
       FilePath = $null
     }
 
-    $destCompletionPath = "${rootDir}\generated\${commandName}.ps1"
+    $destCompletionPath = "${rootDir}\generated\${CommandName}.ps1"
     $result.FilePath = $completionPath
 
-    $command = Get-Command -Name $commandName -ErrorAction 'SilentlyContinue'
+    $command = Get-Command -Name $CommandName -ErrorAction 'SilentlyContinue'
     if ($command -ne $null) {
       $result.Exists = $true
       $recreate = $true
       $destCompletionFile = Get-Item -Path $destCompletionPath -ErrorAction 'SilentlyContinue'
-      $srcCompletionPath = "${rootDir}\static\completion\${commandName}.ps1"
+      $srcCompletionPath = "${rootDir}\templates\completion\${TemplateName}.ps1"
       if ($destCompletionFile -ne $null) {
         $sourceCompletionFileTime = Get-ItemProperty -Path $srcCompletionPath -Name 'LastWriteTime'
         $recreate = $destCompletionFile.LastWriteTime -lt $sourceCompletionFileTime.LastWriteTime
       }
       if ($recreate) {
-        Copy-Item -Path $srcCompletionPath -Destination $destCompletionPath
-        $result.Updated = $true
+        $script = Get-Content -Path $srcCompletionPath
+        $script = $script.Replace('COMMAND_NAME_TOKEN', $CommandName)
+        $script | Set-Content -Path $destCompletionPath
       }
     } elseif (Test-Path -Path $destCompletionPath -PathType 'Leaf') {
       Remove-Item -Path $destCompletionPath

--- a/templates/completion/kube-ctx-ns.ps1
+++ b/templates/completion/kube-ctx-ns.ps1
@@ -15,17 +15,17 @@
 
 # Script based on the kubectl PowerShell completion
 
-function __kubectx_debug {
+function __COMMAND_NAME_TOKEN_debug {
   if ($env:BASH_COMP_DEBUG_FILE) {
     "${args}" | Out-File -Append -FilePath "${env:BASH_COMP_DEBUG_FILE}"
   }
 }
 
-filter __kubectx_escapeStringWithSpecialChars {
+filter __COMMAND_NAME_TOKEN_escapeStringWithSpecialChars {
   $_ -replace '\s|#|@|\$|;|,|''|\{|\}|\(|\)|"|`|\||<|>|&', '`$&'
 }
 
-Register-ArgumentCompleter -CommandName 'kubectx' -ScriptBlock {
+Register-ArgumentCompleter -CommandName 'COMMAND_NAME_TOKEN' -ScriptBlock {
   param(
     $WordToComplete,
     $CommandAst,
@@ -36,9 +36,9 @@ Register-ArgumentCompleter -CommandName 'kubectx' -ScriptBlock {
   $command = $CommandAst.CommandElements
   $command = "${command}"
 
-  __kubectx_debug ''
-  __kubectx_debug '========= starting completion logic =========='
-  __kubectx_debug "WordToComplete: ${WordToComplete} Command: ${command} CursorPosition: ${CursorPosition}"
+  __COMMAND_NAME_TOKEN_debug ''
+  __COMMAND_NAME_TOKEN_debug '========= starting completion logic =========='
+  __COMMAND_NAME_TOKEN_debug "WordToComplete: ${WordToComplete} Command: ${command} CursorPosition: ${CursorPosition}"
 
   # The user could have moved the cursor backwards on the command-line
   # We need to trigger completion from the $CursorPosition location, so we need
@@ -48,20 +48,20 @@ Register-ArgumentCompleter -CommandName 'kubectx' -ScriptBlock {
   if ($command.Length -gt $CursorPosition) {
     $command = $command.Substring(0, $CursorPosition)
   }
-  __kubectx_debug "Truncated command: ${command}"
+  __COMMAND_NAME_TOKEN_debug "Truncated command: ${command}"
 
   $program, $arguments = $command.Split(' ', 2)
   if ($arguments -eq $null) {
     $arguments = @()
-    __kubectx_debug "No arguments"
+    __COMMAND_NAME_TOKEN_debug "No arguments"
   } else {
     $arguments = $arguments.Split(' ')
-    __kubectx_debug "Arguments: ${arguments}"
+    __COMMAND_NAME_TOKEN_debug "Arguments: ${arguments}"
   }
 
   # When at least one agrument is passed, we should not provide more completions
   if ($WordToComplete -eq '' -and $arguments.Length -gt 0) {
-    __kubectx_debug "Only one argument is supported. No more completions"
+    __COMMAND_NAME_TOKEN_debug "Only one argument is supported. No more completions"
     return
   }
 
@@ -70,13 +70,13 @@ Register-ArgumentCompleter -CommandName 'kubectx' -ScriptBlock {
   if ($WordToComplete -ne '') {
     $WordToComplete = $arguments[-1]
   }
-  __kubectx_debug "New WordToComplete: ${WordToComplete}"
+  __COMMAND_NAME_TOKEN_debug "New WordToComplete: ${WordToComplete}"
 
-  __kubectx_debug "Calling ${program} to get available contexts"
+  __COMMAND_NAME_TOKEN_debug "Calling ${program} to get available contexts"
   # Call the command store the output in $out and redirect stderr and stdout to null
   # $values is an array contains each line per element
   Invoke-Expression -OutVariable values "$program" 2>&1 | Out-Null
-  __kubectx_debug "The completions are: ${values}"
+  __COMMAND_NAME_TOKEN_debug "The completions are: ${values}"
 
   # Filter the result
   $values = $values | Where-Object {
@@ -85,7 +85,7 @@ Register-ArgumentCompleter -CommandName 'kubectx' -ScriptBlock {
 
   # Get the current mode
   $mode = (Get-PSReadLineKeyHandler | Where-Object {$_.Key -eq 'Tab'}).Function
-  __kubectx_debug "Mode: $mode"
+  __COMMAND_NAME_TOKEN_debug "Mode: $mode"
 
   $values | ForEach-Object {
     # PowerShell supports three different completion modes
@@ -100,7 +100,7 @@ Register-ArgumentCompleter -CommandName 'kubectx' -ScriptBlock {
     # 3) ResultType     type of completion result
     # 4) ToolTip        text for the tooltip with details about the object
 
-    # kubectx supports only one parameter, so we do not need to add additional spaces at the end
+    # COMMAND_NAME_TOKEN supports only one parameter, so we do not need to add additional spaces at the end
     # The same completion result is returned for all modes
     [System.Management.Automation.CompletionResult]::new(
       $($_ | __kubectl_escapeStringWithSpecialChars),


### PR DESCRIPTION
# Why

The `kubens` tool available on Windows does not provide an interactive mode. It means users have to type a context name instead of choose it from a list. `kubens` works similar as `kubectx` - returns available values when called without parameters.

# What

The `kubectx` completion script is converted to a template which is reused for the `kubens` completion.